### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - '**.rs'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/8](https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the workflow only checks out the repository and runs Rust-related checks, it likely only needs `contents: read` permission. This ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
