### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -1,5 +1,8 @@
 name: C# Build Check
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,4 +1,6 @@
 name: Java Build Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/7](https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only involves checking out the repository and compiling Java files, it likely only needs `contents: read` permission. This ensures that the workflow has the least privilege necessary to perform its tasks.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
