### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,5 +1,8 @@
 name: Python Run Check
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/6](https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow only reads repository contents and does not perform any write operations, the `permissions` block should be set to `contents: read`. This change should be applied at the root level of the workflow to cover all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
