### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - '**.js'
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/12](https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/12)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the minimum permissions required for the workflow. Since the workflow only needs to read the repository contents (e.g., to check out the code), the `contents: read` permission is sufficient. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
