### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go Build Check
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/11](https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/11)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow only reads repository contents and does not perform any write operations, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
