### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - '**.cpp'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/10](https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the provided workflow, it primarily checks out the repository and compiles C++ files, so it only needs `contents: read` permission. This ensures that the workflow cannot perform any unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
