### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -1,4 +1,6 @@
 name: C Build Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/9](https://github.com/diegoabeltran16/LeetCode-solved/security/code-scanning/9)

To fix the issue, add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents, the `contents: read` permission is sufficient. This will restrict the `GITHUB_TOKEN` to read-only access, minimizing the risk of unintended write operations.

The `permissions` block should be added directly under the `name` field to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
